### PR TITLE
Reset nonce after each request

### DIFF
--- a/lib/cryptopia/api/private.rb
+++ b/lib/cryptopia/api/private.rb
@@ -118,13 +118,19 @@ module Cryptopia
         @url = self.class.base_uri + endpoint
         @options = options.to_json
 
-        self.class.post(
+        response = self.class.post(
           endpoint,
           body: @options,
           headers: {
             'Authorization' => "amx #{authorization_formatted_value}",
             'Content-Type' => 'application/json'
           })
+
+        # Nonce should be reset after each request to avoid
+        # "Nonce has already been used for this request." error
+        @nonce = nil
+
+        response
       end
 
       def keys_is_not_present?

--- a/lib/cryptopia/version.rb
+++ b/lib/cryptopia/version.rb
@@ -1,3 +1,3 @@
 module Cryptopia
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
A nonce should only be used once but doesn't get reset after a call to `auth_post`, this leads to authenticated requests _after_ the first failing with an error like:

```json
{
   "Error": "Nonce has already been used for this request.",
  "Success": false
}
```

Also bumps version number to `0.1.1` in prep for release to RubyGems.